### PR TITLE
chore: increases seeder restarts

### DIFF
--- a/seeder.railway.json
+++ b/seeder.railway.json
@@ -5,7 +5,8 @@
         "dockerfilePath": "./dockerfiles/Dockerfile.seeder"
     },
     "deploy": {
-        "restartPolicyType": "NEVER",
+        "restartPolicyType": "ON_FAILURE",
+        "restartPolicyMaxRetries": 20,
         "sleepApplication": false
     }
 }


### PR DESCRIPTION
Increases seeder restarts. This is needed for when the database or the meilisearch instance go down due to app sleeping and the seeder needs to wait for them to be online in order to be successful.