### PR TITLE
fix : use class binding to fix AppLayout

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -18,7 +18,7 @@ defineProps<Props>();
         <div class="sticky left-0 right-0 top-0 z-30">
             <Navbar />
         </div>
-        <main class="flex flex-1">
+        <main :class="$attrs.class" class="flex-1">
             <slot />
         </main>
     </div>

--- a/resources/js/Pages/Maintenance.vue
+++ b/resources/js/Pages/Maintenance.vue
@@ -5,7 +5,7 @@ import AppLayout from "@/Layouts/AppLayout.vue";
 
 <template>
 
-    <AppLayout title="Home" class="flex flex-col">
+    <AppLayout title="Home" class="flex">
 
         <div class="absolute inset-0 background z-2"></div>
         <div class="absolute inset-0 gradient-overlay z-0"></div>


### PR DESCRIPTION
Instead of using a prop, we have implemented class binding to fix the AppLayout. This PR addresses the issue where non-maintenance pages were unintentionally affected after the implementation of #15 by me and @tomaspalma.